### PR TITLE
fix(security): bump js-yaml to 4.2.0 to close Dependabot alert #43

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "word-wrap": "npm:@aashutoshrathi/word-wrap@1.2.5",
     "semver": "npm:semver@7.5.4",
     "form-data": "npm:form-data@4.0.6",
-    "js-yaml": "npm:js-yaml@4.1.1",
+    "js-yaml": "npm:js-yaml@4.2.0",
     "langsmith": "0.6.3",
     "lodash-es": "4.18.1",
     "qs": "6.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,10 +2291,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.0, "js-yaml@npm:js-yaml@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^4.1.0, "js-yaml@npm:js-yaml@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

- Bumps the `js-yaml` yarn resolution from `npm:js-yaml@4.1.1` to `npm:js-yaml@4.2.0` to close Dependabot alert [#43](https://github.com/trutohq/truto-langchainjs-toolset/security/dependabot/43).

## Context

The previous resolution pinned `js-yaml` to `4.1.1`, which is still within the **vulnerable range** (`>= 4.0.0, <= 4.1.1`) for the advisory:

> JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases

The first patched version is **`4.2.0`**, which this PR pins.

`js-yaml` is a **transitive dev dependency** (via `eslint`) and is not imported anywhere in `src/`. The existing open Dependabot PR #33 only bumps to `4.1.1`, which does **not** close this alert — this PR supersedes it.

## Verification

- `yarn install` — clean, lockfile updated
- `yarn why js-yaml` → `Found "js-yaml@4.2.0"`
- `yarn build` — passed (parcel, dist outputs unchanged in size)
- `yarn run check` (`tsc --noEmit`) — passed
- No remaining `js-yaml@4.1.1` or `4.1.0` references in `yarn.lock`

## Risk

Low. Patch-level bump within major 4; only affects dev tooling (eslint). No runtime/user-facing code paths touch this package.

## Test plan

- [x] `yarn install`
- [x] `yarn build`
- [x] `yarn run check`
- [ ] Confirm Dependabot alert #43 auto-closes after merge to `main`

Made with [Cursor](https://cursor.com)