### PR TITLE
fix(security): bump svgo to 2.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "brace-expansion": "5.0.8",
     "minimatch": "3.1.5",
     "picomatch": "2.3.2",
-    "svgo": "2.8.1",
+    "svgo": "2.8.3",
     "@parcel/reporter-dev-server": "2.16.4",
     "zod": "npm:zod@4.4.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,10 +3022,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-svgo@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.1.tgz#44baf6865caaa7eef4087fa2e08c50f6c088c346"
-  integrity sha512-BYibJ2/mV0Xv9c49ludbc/oN1MJwJZxikJNi7iLrOMJZpsVhch56/V6oCW8wcRqeBaNLE60C6biLE1GMw43bag==
+svgo@2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.3.tgz#8de2fa579f3f7429dec3fb86471005cf46fb483a"
+  integrity sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==
   dependencies:
     commander "^7.2.0"
     css-select "^4.1.3"


### PR DESCRIPTION
## Summary
- Bump `svgo` resolution from 2.8.1 to 2.8.3 to address the known vulnerability in the locked dependency.

## Test plan
- [ ] Confirm `yarn install` resolves `svgo@2.8.3`
- [ ] Confirm Dependabot / security advisory for svgo is cleared after merge


Made with [Cursor](https://cursor.com)